### PR TITLE
changes to improve front end and back end

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,17 @@
+**Frontend**
+
+Virtualized table: Switched to react-virtuoso (TableVirtuoso) so only visible rows render, keeping the UI responsive with thousands of items.
+
+Explicit search trigger: Added a Search button (Enter submits) to avoid spamming the API on every keystroke. (Follow-up: add 200–300ms debounce.)
+
+Server-driven results: Input → /api/advocates?q=...; removed client-side full-dataset filtering.
+
+Basic caching & cancellation: Cache results by query and cancel stale requests.
+
+UI polish: Improve design using Tailwind, labeled search input, and result count.
+
+**Backend**
+
+Search endpoint: GET /api/advocates?q= performs server-side filtering; we no longer send the full dataset to the browser.
+
+Indexing plan (follow-up for scale): Add a generated lower-cased search_blob for fast substring search?

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "solace-candidate-assignment",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "drizzle-orm": "^0.32.1",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-virtuoso": "^4.14.0"
       },
       "devDependencies": {
         "@types/node": "^20.14.12",
@@ -1417,6 +1419,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {
@@ -4057,6 +4070,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.14.0.tgz",
+      "integrity": "sha512-fR+eiCvirSNIRvvCD7ueJPRsacGQvUbjkwgWzBZXVq+yWypoH7mRUvWJzGHIdoRaCZCT+6mMMMwIG2S1BW3uwA==",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "seed": "node --loader esbuild-register/loader -r esbuild-register ./src/db/seed/index.ts"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.32.1",
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-virtuoso": "^4.14.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.12",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,42 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+// app/api/advocates/route.ts
+import db from "@/db";
+import { advocates } from "@/db/schema";
+import { ilike, or, sql } from "drizzle-orm";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = (searchParams.get("q") ?? "").trim();
+  if (!q) {
+    const data = await db.select().from(advocates);
+    return Response.json({ data });
+  }
 
-  const data = advocateData;
+  const like = `%${q}%`;
+
+  const data = await db
+    .select()
+    .from(advocates)
+    .where(
+      or(
+        ilike(advocates.firstName, like),
+        ilike(advocates.lastName, like),
+        ilike(advocates.city, like),
+        ilike(advocates.degree, like),
+        sql<boolean>`EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(
+            CASE
+              WHEN ${advocates.specialties} IS NULL THEN '[]'::jsonb
+              WHEN jsonb_typeof(${advocates.specialties}) = 'array' THEN ${advocates.specialties}
+              ELSE jsonb_build_array(${advocates.specialties})
+            END
+          ) s
+          WHERE s ILIKE ${like}
+        )`,
+        sql<boolean>`(${advocates.yearsOfExperience})::text ILIKE ${like}`,
+        sql<boolean>`(${advocates.phoneNumber})::text ILIKE ${like}`
+      )
+    );
 
   return Response.json({ data });
 }

--- a/src/app/errors.ts
+++ b/src/app/errors.ts
@@ -1,0 +1,18 @@
+export type AppError =
+  | { type: "NetworkError"; message: string; status?: number }
+  | { type: "ValidationError"; message: string; field?: string }
+  | { type: "UnknownError"; message: string };
+
+export function AppErrorTypes(e: unknown): AppError {
+  if (e instanceof Response) {
+    return {
+      type: "NetworkError",
+      message: `HTTP ${e.status} ${e.statusText}`,
+      status: e.status,
+    };
+  }
+  if (e instanceof Error) {
+    return { type: "UnknownError", message: e.message };
+  }
+  return { type: "UnknownError", message: "Unexpected error" };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,91 +1,223 @@
 "use client";
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  forwardRef,
+  HTMLAttributes,
+} from "react";
+import { TableVirtuoso } from "react-virtuoso";
+import type { AppError } from "./errors";
+import { AppErrorTypes } from "./errors";
 
-import { useEffect, useState } from "react";
+interface Advocate {
+  id: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: string;
+}
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [rows, setRows] = useState<Advocate[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<AppError | null>(null);
+  const cacheRef = useRef<Map<string, Advocate[]>>(new Map());
 
   useEffect(() => {
-    console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
-    });
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/advocates`, { cache: "no-store" });
+        if (!res.ok) throw res;
+        const json = await res.json();
+        const data: Advocate[] = (json.data ?? []) as Advocate[];
+        setRows(data);
+      } catch (e: unknown) {
+        setError(AppErrorTypes(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
+  const handleSearch = async () => {
+    const q = searchTerm.trim();
+    const key = q.toLowerCase();
+    if (cacheRef.current.has(key)) {
+      setRows(cacheRef.current.get(key)!);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const qs = q ? `?q=${encodeURIComponent(q)}` : "";
+      const res = await fetch(`/api/advocates${qs}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) throw res;
+      const json = await res.json();
+      const data: Advocate[] = (json.data ?? []) as Advocate[];
+      cacheRef.current.set(key, data);
+      setRows(data);
+    } catch (e: unknown) {
+      if ((e as any)?.name === "AbortError") return;
+      setError(AppErrorTypes(e));
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
-  };
+  if (loading) {
+    return (
+      <main className="flex items-center justify-center min-h-screen bg-gray-50">
+        <span className="text-lg text-gray-500">Loading…</span>
+      </main>
+    );
+  }
+  if (error) {
+    return (
+      <main className="flex items-center justify-center min-h-screen bg-gray-50">
+        <span className="text-red-600 text-lg">Error: {error.message}</span>
+      </main>
+    );
+  }
 
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
+    <main className="min-h-screen bg-gray-50 py-8 px-2 md:px-4">
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-8 text-center">
+          Solace Advocates
+        </h1>
+
+        <div className="mb-8 flex flex-col md:flex-row items-center gap-4 bg-white p-6 rounded-lg shadow">
+          <div className="flex-1">
+            <label
+              htmlFor="search"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
+              Search (server-side)
+            </label>
+            <input
+              id="search"
+              type="search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Name, city, degree, specialty…"
+              className="w-full border border-gray-300 rounded-md px-2 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+            <div className="mt-2 text-xs text-gray-500">
+              Searching for: <span className="font-semibold">{searchTerm}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleSearch}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-md shadow"
+          >
+            Search
+          </button>
+          <span className="text-sm text-gray-600">
+            {rows.length} result{rows.length === 1 ? "" : "s"}
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setSearchTerm("");
+              handleSearch();
+            }}
+            className="bg-red-600 hover:bg-red-700 text-white font-semibold px-6 py-2 rounded-md shadow"
+          >
+            Reset Search
+          </button>
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-gray-200 shadow bg-white">
+          <TableVirtuoso
+            data={rows}
+            style={{ height: "70vh" }}
+            components={{
+              Table: (props) => (
+                <table
+                  {...props}
+                  className="min-w-[900px] w-full divide-y divide-gray-200"
+                />
+              ),
+              TableHead: forwardRef<
+                HTMLTableSectionElement,
+                HTMLAttributes<HTMLTableSectionElement>
+              >((props, ref) => (
+                <thead ref={ref} {...props} className="bg-gray-100" />
+              )),
+              TableRow: (props) => (
+                <tr {...props} className="hover:bg-blue-50" />
+              ),
+              TableBody: forwardRef<HTMLTableSectionElement>((props, ref) => (
+                <tbody
+                  ref={ref}
+                  {...props}
+                  className="divide-y divide-gray-200"
+                />
+              )),
+            }}
+            fixedHeaderContent={() => (
               <tr>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
-                  ))}
-                </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  First Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  Last Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  City
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  Degree
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  Specialties
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  Years
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                  Phone
+                </th>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            )}
+            itemContent={(_, a) => (
+              <>
+                <td className="px-4 py-3 whitespace-nowrap">{a.firstName}</td>
+                <td className="px-4 py-3 whitespace-nowrap">{a.lastName}</td>
+                <td className="px-4 py-3 whitespace-nowrap">{a.city}</td>
+                <td className="px-4 py-3 whitespace-nowrap">{a.degree}</td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex flex-wrap gap-1.5">
+                    {a.specialties.map((s, i) => (
+                      <span
+                        key={`${a.id}-spec-${i}`}
+                        className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] text-indigo-700 ring-1 ring-inset ring-indigo-200"
+                      >
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-center">
+                  {a.yearsOfExperience}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">{a.phoneNumber}</td>
+              </>
+            )}
+          />
+        </div>
+      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,6 @@ export default function Home() {
       cacheRef.current.set(key, data);
       setRows(data);
     } catch (e: unknown) {
-      if ((e as any)?.name === "AbortError") return;
       setError(AppErrorTypes(e));
     } finally {
       setLoading(false);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,14 +1,12 @@
+import "dotenv/config";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 const setup = () => {
   if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    throw new Error(
+      "DATABASE_URL is not set. Please check your .env file and environment configuration."
+    );
   }
 
   // for query purposes


### PR DESCRIPTION
**Frontend**

Virtualized table: Switched to react-virtuoso (TableVirtuoso) so only visible rows render, keeping the UI responsive with thousands of items.

Explicit search trigger: Added a Search button (Enter submits) to avoid spamming the API on every keystroke. (Follow-up: add 200–300ms debounce.)

Server-driven results: Input → /api/advocates?q=...; removed client-side full-dataset filtering.

Basic caching & cancellation: Cache results by query and cancel stale requests.

UI polish: Improve design using Tailwind, labeled search input, and result count. 

TO DO: Search by pressing enter. 

**Backend**

Search endpoint: GET /api/advocates?q= performs server-side filtering; we no longer send the full dataset to the browser.

Indexing plan (follow-up for scale): Add a generated lower-cased search_blob for fast substring search?